### PR TITLE
feat: add 5/10/15 min pre-prayer reminders

### DIFF
--- a/cycle.py
+++ b/cycle.py
@@ -11,12 +11,16 @@ from scrapeAPI import *
 from blocked import *
 from storage import save_data
 from main import database_prayer_times, loadArr, delete_user
-from text import reminder_text
+from text import reminder_text, pre_reminder_text
 
 global upcoming_prayer_time
 upcoming_prayer_time = None
 global change_prayer_time
 change_prayer_time = None
+
+# Memo of (prayer_name, minutes_before, YYYY-MM-DD) tuples already fired.
+# Cleared at midnight when prayer times refresh.
+pre_reminder_sent = set()
 
 
 # Bot token
@@ -73,6 +77,35 @@ async def bulk_send_reminders(chat_ids: List[str], prayer: str, masa: str, upcom
     tasks = [send_reminder(chat_id, prayer, masa, chat_ids, upcoming_prayer_name, next_prayer, next_prayer_time) for chat_id in chat_ids]
     await asyncio.gather(*tasks)
 
+# Pre-reminder dispatch (fires N minutes before a prayer)
+async def solat_pre_reminder(chat_id, prayer, masa, minutes_before):
+    msg = await pre_reminder_text(prayer, masa, minutes_before)
+    await sbot.send_message(chat_id, msg, 'Markdown')
+
+async def send_pre_reminder(chat_id: str, prayer: str, masa: str, minutes_before: int):
+    try:
+        await solat_pre_reminder(chat_id, prayer, masa, minutes_before)
+        logger.info(f"Sent {minutes_before}-min pre-reminder to {chat_id} for {prayer}")
+        print(f"sent {minutes_before}-min pre-reminder", chat_id)
+
+    except telebot.apihelper.ApiException as e:
+        if "bot was blocked by the user" in e.result.text:
+            logger.warning(f"Bot was blocked by user {chat_id}")
+            print(f"\n\nBot was blocked by user {chat_id}\n\n")
+        else:
+            logger.error(f"An error occurred in sending pre-reminders: {e}")
+    except Exception as e:
+        if "403" in str(e) and "blocked" in str(e).lower():
+            logger.warning(f"Bot was blocked by user {chat_id} (caught in generic Exception)")
+        else:
+            logger.error(f"Unexpected error for {chat_id}: {e}")
+    finally:
+        return
+
+async def bulk_send_pre_reminders(chat_ids: List[str], prayer: str, masa: str, minutes_before: int):
+    tasks = [send_pre_reminder(chat_id, prayer, masa, minutes_before) for chat_id in chat_ids]
+    await asyncio.gather(*tasks)
+
 # Schedule the scraper to run daily at 5 AM SGT
 async def scheduleRun(chat_id_dict):
 
@@ -110,13 +143,20 @@ async def scheduleRun(chat_id_dict):
     print("Scheduled daily has been run\n")
 
 
-async def cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr):
+async def cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr,
+                     custom_5_enabled_arr=None, custom_10_enabled_arr=None,
+                     custom_15_enabled_arr=None):
 
     now = datetime.now(sg_timezone) # Use the Singapore timezone
     new_day = now.replace(hour=23, minute=59, second=0, microsecond=0)
 
     global upcoming_prayer_time, change_prayer_time
     global database_prayer_times
+    global pre_reminder_sent
+
+    custom_5_enabled_arr = custom_5_enabled_arr or []
+    custom_10_enabled_arr = custom_10_enabled_arr or []
+    custom_15_enabled_arr = custom_15_enabled_arr or []
     
     # Get raw prayer time data
     solatTimesRaw = database_prayer_times
@@ -134,7 +174,8 @@ async def cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr):
     daily_arr = daily_enabled_arr
     if reminders_arr is None or not reminders_arr or daily_arr is None or not daily_arr:
         logger.error("Failed to retrieve runtime reminder/daily array from local database")
-        reminders_enabled_arr, daily_enabled_arr = await loadArr(chat_id_dict)
+        (reminders_enabled_arr, daily_enabled_arr,
+         custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr) = await loadArr(chat_id_dict)
         return
     #print("reminders_arr:", reminders_arr)
     #print("daily_arr:", daily_arr)
@@ -144,6 +185,7 @@ async def cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr):
     if now < AM_12 + timedelta(minutes=2) and now >= AM_12:
         logger.info("Updating Prayer Times")
         database_prayer_times = await RefreshPrayerTime()
+        pre_reminder_sent.clear()
         print("Updated: ", database_prayer_times)
         logger.info("Entering deep sleep after 12:00 AM")
         await asyncio.sleep(17100)
@@ -221,7 +263,35 @@ async def cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr):
     upcoming_prayer_time = upcoming_prayer_time + timedelta(seconds=3)
     print("Alert time upcoming: ", upcoming_prayer_time)
 
-        
+    # Pre-reminder dispatch (5/10/15 min before the upcoming prayer)
+    # Sleeping 61s after a fire skips the rest of the 1-minute window so the
+    # same pre-reminder won't re-fire. Safe because slots are ≥5 min apart.
+    pre_slots = [
+        (5,  custom_5_enabled_arr),
+        (10, custom_10_enabled_arr),
+        (15, custom_15_enabled_arr),
+    ]
+    # --- Memo-based variant (uncomment + remove the sleep below to switch back) ---
+    # today_key = now.strftime('%Y-%m-%d')
+    # for minutes_before, group_arr in pre_slots:
+    #     if not group_arr:
+    #         continue
+    #     pre_time = upcoming_prayer_time - timedelta(minutes=minutes_before)
+    #     memo_key = (upcoming_prayer_name, minutes_before, today_key)
+    #     if (now >= pre_time
+    #             and now < pre_time + timedelta(minutes=1)
+    #             and memo_key not in pre_reminder_sent):
+    #         await bulk_send_pre_reminders(group_arr, upcoming_prayer_name, masa, minutes_before)
+    #         pre_reminder_sent.add(memo_key)
+    # --- end memo variant ---
+    for minutes_before, group_arr in pre_slots:
+        if not group_arr:
+            continue
+        pre_time = upcoming_prayer_time - timedelta(minutes=minutes_before)
+        if now >= pre_time and now < pre_time + timedelta(minutes=1):
+            await bulk_send_pre_reminders(group_arr, upcoming_prayer_name, masa, minutes_before)
+            await asyncio.sleep(61)
+
     # If time is within 1 minute after azan
     if now < upcoming_prayer_time + timedelta(minutes=1) and now >= upcoming_prayer_time:
         prayer_keys = list(solatTimes.keys())
@@ -238,20 +308,3 @@ async def cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr):
 
         await bulk_send_reminders(reminders_enabled_arr, prayer, masa, upcoming_prayer_name, next_prayer_name, next_prayer_time)
         await asyncio.sleep(61)
-
-
-    '''
-        for loop and if conditionals updated. do a new for loop and shift these one tab left when reimplementing
-        # Check if 'custom_duration' key exists in chat_info
-        if chat_info['custom_durations']:
-            # Trigger the custom reminders based on custom durations
-            for i, custom_duration in enumerate(chat_info.get('custom_durations', [])):
-                # Calculate the time difference as a timedelta
-                time_difference = last_prayer_time - timedelta(minutes=custom_duration)
-                if now >= time_difference and now <= time_difference + timedelta(minutes=1) and not chat_info['custom_reminder_sent']:
-                    # Trigger the custom reminder for slot i
-                    send_custom_reminder(sbot, chat_id, f"{prayer}", masa, custom_duration)
-                    chat_info['custom_reminder_sent'] = True
-                    t = Timer(65, set_custom_reminder_sent_false, args=(chat_info, ))
-                    t.start()
-    '''

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from logs import logger
 import asyncio
-import telebot 
+import telebot
 from telebot import apihelper
 from telebot.async_telebot import AsyncTeleBot
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
@@ -35,8 +35,11 @@ daily_enabled_arr = []
 custom_5_enabled_arr = []
 custom_10_enabled_arr = []
 custom_15_enabled_arr = []
-custom_20_enabled_arr = []
-custom_25_enabled_arr = []
+
+def _purge_chat_id_from_custom_arrays(chat_id):
+    for arr in (custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr):
+        if chat_id in arr:
+            arr.remove(chat_id)
 
 # Define the menus
 main_menu = ReplyKeyboardMarkup(resize_keyboard=True)
@@ -45,11 +48,12 @@ info_menu = ReplyKeyboardMarkup(resize_keyboard=True)
 donate_menu = ReplyKeyboardMarkup(resize_keyboard=True)
 
 # Main Menu buttons
-main_menu.row(KeyboardButton('Upcoming Timings (In Progress)'), KeyboardButton('Current Timings'))
+main_menu.row(KeyboardButton('Upcoming Timings'), KeyboardButton('Current Timings'))
 main_menu.row(KeyboardButton('Settings'), KeyboardButton('Information'))
 main_menu.row(KeyboardButton('Help'))
 
 toggle_menu.row(KeyboardButton('Reminders'), KeyboardButton('Daily Updates'))
+toggle_menu.row(KeyboardButton('Pre-Reminders'))
 toggle_menu.row(KeyboardButton('Back'))
 
 info_menu.row(KeyboardButton('Qiblat'), KeyboardButton('Donate'))
@@ -134,6 +138,8 @@ async def handle_click(message):
     elif message.text == 'Daily Updates' or message.text == '/daily':
         await daily_command(message)
         await settings_command(message)
+    elif message.text == 'Pre-Reminders' or message.text == '/prereminder':
+        await prereminder_command(message)
     elif message.text == 'Back':
         await sbot.send_message(message.chat.id, "Back to main menu:", reply_markup=main_menu)
     elif message.text == 'Information':
@@ -244,9 +250,10 @@ async def delUser(message):
             # Remove the chat ID from the arrays
             reminders_enabled_arr.remove(remove_chat_id)  # Remove from the array
             daily_enabled_arr.remove(remove_chat_id)  # Remove from the array
-        
+            _purge_chat_id_from_custom_arrays(remove_chat_id)
+
         print("User: ", remove_chat_id, " has been deleted\n")
-        await sbot.send_message(message.chat.id, notify)     
+        await sbot.send_message(message.chat.id, notify)
     else:
         return
     
@@ -292,12 +299,15 @@ async def updateDB(message):
         admin_message = "Welcome Admin, the database has been updated.\n"
 
         for chat_id, chat_data in chat_id_dict.items():
+            existing_durations = chat_data.get('custom_durations', [])
+            normalized_durations = (existing_durations + [False, False, False])[:3]
             new_chat_data = {
             'reminders_enabled': chat_data.get('reminders_enabled', True),
             'daily_timings_enabled': chat_data.get('daily_timings_enabled', True),
-            'custom_durations': chat_data.get('custom_durations', [False, False, False, False, False]),
+            'custom_durations': normalized_durations,
             }
             chat_id_dict[chat_id] = new_chat_data
+        await save_data(chat_id_dict)
         
         await sbot.send_message(message.chat.id, admin_message)  
         print("The database has been updated.\n")      
@@ -358,7 +368,7 @@ async def exitBot(message):
     if message.chat.id == 51719761:
         print("Admin has initiated bot shutdown.")
         logger.info("Admin has initiated bot shutdown.")
-        await shutdown()     
+        await shutdown()
     else:
         return
 
@@ -373,7 +383,7 @@ async def checker(chat_id):
         chat_id_dict[chat_id] = {
             'reminders_enabled': True,
             'daily_timings_enabled': True,
-            'custom_durations': [False, False, False, False, False], # Time for 5, 10, 15, 20, 30
+            'custom_durations': [False, False, False], # Time for 5, 10, 15
         }
 
         await save_data(chat_id_dict)
@@ -421,6 +431,7 @@ async def stop_command(message):
     chat_id = str(message.chat.id)
     if chat_id in chat_id_dict:
         del chat_id_dict[chat_id]
+        _purge_chat_id_from_custom_arrays(chat_id)
         await save_data(chat_id_dict)
         logger.info(f"Removed {chat_id} from database.")
     await sbot.send_message(message.chat.id, "You will no longer receive notifications. Thank you for using my bot!")
@@ -448,6 +459,14 @@ async def settings_command(message):
     reply = "_Current Settings:_\n\n"
     reply += f"*Reminders Enabled:* {rem_tog}\n"
     reply += f"*Daily Timings Enabled:* {dly_tog}\n\n"
+
+    durations = chat_info.get('custom_durations', [False, False, False])
+    durations = (durations + [False, False, False])[:3]
+    labels = ['5min', '10min', '15min']
+    reply += "*Pre\\-Reminders:*\n"
+    for i, lbl in enumerate(labels):
+        state = "On ✅" if durations[i] else "Off ❌"
+        reply += f"  {lbl}: {state}\n"
 
     # Send the message with prayer times
     await sbot.send_message(message.chat.id, reply, 'MarkdownV2')
@@ -557,6 +576,74 @@ async def toggle_command(message):
         reminders_enabled_arr.remove(chat_id)  # Remove from the array
         await sbot.send_message(message.chat.id, "Azan reminders are now disabled. \u274c")
 
+# /prereminder command handler
+@sbot.message_handler(commands=['prereminder'])
+async def prereminder_command(message):
+    await checker(message.chat.id)
+    chat_id = str(message.chat.id)
+    chat_info = chat_id_dict[chat_id]
+
+    durations = chat_info.get('custom_durations', [False, False, False])
+    durations = (durations + [False, False, False])[:3]
+    chat_info['custom_durations'] = durations
+
+    kb = InlineKeyboardMarkup(row_width=1)
+    for idx, label in enumerate(['5 min', '10 min', '15 min']):
+        mark = '✅' if durations[idx] else '❌'
+        kb.add(InlineKeyboardButton(f"{label} {mark}", callback_data=f'prerem_{idx}'))
+
+    await sbot.send_message(
+        message.chat.id,
+        "Toggle pre-prayer reminders (any combination):",
+        reply_markup=kb,
+    )
+
+# Callback handler for the inline pre-reminder toggle keyboard
+@sbot.callback_query_handler(func=lambda call: call.data.startswith('prerem_'))
+async def handle_prereminder_toggle(call):
+    global custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr
+
+    idx = int(call.data.split('_')[1])
+    minutes = [5, 10, 15][idx]
+    chat_id = str(call.message.chat.id)
+
+    # Ensure the user record exists and has a 3-slot array
+    await checker(chat_id)
+    chat_info = chat_id_dict[chat_id]
+    durations = (chat_info.get('custom_durations', []) + [False, False, False])[:3]
+    durations[idx] = not durations[idx]
+    chat_info['custom_durations'] = durations
+
+    arrays = [custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr]
+    target_arr = arrays[idx]
+    if durations[idx]:
+        if chat_id not in target_arr:
+            target_arr.append(chat_id)
+    else:
+        if chat_id in target_arr:
+            target_arr.remove(chat_id)
+
+    await save_data(chat_id_dict)
+
+    await sbot.answer_callback_query(
+        call.id,
+        f"{minutes}-min pre-reminder {'enabled' if durations[idx] else 'disabled'}",
+    )
+
+    # Re-render the inline keyboard in place with updated marks
+    kb = InlineKeyboardMarkup(row_width=1)
+    for i, label in enumerate(['5 min', '10 min', '15 min']):
+        mark = '✅' if durations[i] else '❌'
+        kb.add(InlineKeyboardButton(f"{label} {mark}", callback_data=f'prerem_{i}'))
+    try:
+        await sbot.edit_message_reply_markup(
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            reply_markup=kb,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to edit pre-reminder keyboard: {e}")
+
 # /menu_off command handler
 @sbot.message_handler(regexp='menu_off')
 @sbot.message_handler(commands=['menu_off'])
@@ -578,6 +665,7 @@ async def help_command(message):
       "/toggle - Toggle reminders on or off",
       "/timings - Get current prayer times",
       "/daily - Toggle daily prayer times (at 5AM) notifications on or off",
+      "/prereminder - Toggle 5/10/15 min pre-prayer reminders",
       # "/list - List current slots\n",
       # "/customreminder [<index>] <minutes> - Set or edit a custom reminder (0 minutes to disable)\n(e.g. /customreminder 30 creates a new 30 minute pre-reminder while /customreminder 1 45 edits the pre-reminder in Slot 1 to 45 minutes.\nOmitting <index> changes the bot to 'create' mode\nNote: This is the only command with a format)\n",
       # "/patch - Lists updates to the bot", 
@@ -629,27 +717,44 @@ async def patch_command(message):
 def NonAsync_loadArr(chat_id_dict):
     reminders_enabled_arr = []
     daily_enabled_arr = []
+    custom_5 = []
+    custom_10 = []
+    custom_15 = []
     for chat_id, chat_data in chat_id_dict.items():
         if chat_data.get('reminders_enabled', True):
             reminders_enabled_arr.append(chat_id)
         if chat_data.get('daily_timings_enabled', True):
             daily_enabled_arr.append(chat_id)
-    
-    return [reminders_enabled_arr, daily_enabled_arr]
+        durations = (chat_data.get('custom_durations', []) + [False, False, False])[:3]
+        if durations[0]:
+            custom_5.append(chat_id)
+        if durations[1]:
+            custom_10.append(chat_id)
+        if durations[2]:
+            custom_15.append(chat_id)
+
+    return [reminders_enabled_arr, daily_enabled_arr, custom_5, custom_10, custom_15]
 
 
 # Populate the arrays based on the loaded data
 async def loadArr(chat_id_dict):
-    # reminders_enabled_arr = []
-    # daily_enabled_arr = []
     global reminders_enabled_arr, daily_enabled_arr
+    global custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr
     for chat_id, chat_data in chat_id_dict.items():
         if chat_data.get('reminders_enabled', True):
             reminders_enabled_arr.append(chat_id)
         if chat_data.get('daily_timings_enabled', True):
             daily_enabled_arr.append(chat_id)
-    
-    return [reminders_enabled_arr, daily_enabled_arr]
+        durations = (chat_data.get('custom_durations', []) + [False, False, False])[:3]
+        if durations[0]:
+            custom_5_enabled_arr.append(chat_id)
+        if durations[1]:
+            custom_10_enabled_arr.append(chat_id)
+        if durations[2]:
+            custom_15_enabled_arr.append(chat_id)
+
+    return [reminders_enabled_arr, daily_enabled_arr,
+            custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr]
 
 
 # Deleteing user
@@ -658,6 +763,7 @@ async def delete_user(remove_chat_id):
     remove_chat_id = str(remove_chat_id)
     if remove_chat_id in chat_id_dict:
         chat_id_dict.pop(remove_chat_id, None)
+        _purge_chat_id_from_custom_arrays(remove_chat_id)
         text = f"User: {remove_chat_id} has been deleted\n"
         logger.info(text)
         await sbot.send_message(51719761, text)
@@ -677,7 +783,14 @@ async def shutdown():
 async def main():
     while(True):
         try:
-            await cycleCheck(chat_id_dict, reminders_enabled_arr, daily_enabled_arr)
+            await cycleCheck(
+                chat_id_dict,
+                reminders_enabled_arr,
+                daily_enabled_arr,
+                custom_5_enabled_arr,
+                custom_10_enabled_arr,
+                custom_15_enabled_arr,
+            )
 
             print("Suspend")
             await asyncio.sleep(1)
@@ -703,7 +816,8 @@ if __name__ == '__main__':
     print("User profiles have been loaded")
     logger.info("User profiles have been loaded")
     database_prayer_times = NonAsync_RefreshPrayerTime()
-    reminders_enabled_arr, daily_enabled_arr = NonAsync_loadArr(chat_id_dict)
+    (reminders_enabled_arr, daily_enabled_arr,
+     custom_5_enabled_arr, custom_10_enabled_arr, custom_15_enabled_arr) = NonAsync_loadArr(chat_id_dict)
     print("Prayer Times have been loaded")
     logger.info("Prayer Times have been loaded")
 

--- a/text.py
+++ b/text.py
@@ -3,6 +3,24 @@ from logs import logger
 
 from funcs import format_text
 
+async def pre_reminder_text(prayer, masa, minutes_before):
+    prayer = prayer.capitalize()
+
+    header_art = {
+        'Subuh': '\U0001F30C',
+        'Syuruk': '\U0001F305',
+        'Zohor': '\U0001F3D9',
+        'Asar': '\U0001F307',
+        'Maghrib': '\U0001F304',
+        'Isyak': '\U0001F303',
+    }.get(prayer, '\U0001F54B')
+
+    return (
+        f"⏰ *Reminder:* {prayer} prayer in *{minutes_before} minutes* "
+        f"({masa}) {header_art}\n\n"
+        f"Prepare for prayer."
+    )
+
 async def reminder_text(chat_id, prayer, masa, next_prayer=None, next_prayer_time=None):
     
     prayer = prayer.capitalize()


### PR DESCRIPTION
Adds opt-in pre-prayer reminders so users get a heads-up 5, 10, and/or 15 minutes before each azan. Multi-select per user (any combination).

Schema (chat_id_dict[chat_id]):
  custom_durations: [bool, bool, bool]   # [5min, 10min, 15min]

UI:
  - New "Pre-Reminders" button on the Settings (toggle) menu
  - Inline keyboard with ✅/❌ per slot, toggled in place
  - /prereminder command does the same
  - /settings shows per-slot state
  - /help lists /prereminder

Scheduling (cycle.py):
  - cycleCheck takes the three new arrays
  - Pre-reminder dispatch fires N min before the upcoming prayer
  - Sleeps 61s after a fire to skip the 1-min match window
  - Memo-based variant kept as commented scaffolding for future use

Migration:
  - /updatedb slices/pads existing custom_durations to length 3
  - checker() seeds 3-slot arrays for new users
  - Removed unused custom_20/custom_25 runtime arrays
  - Removed dead commented scaffolding at the bottom of cycle.py