### PR TITLE
fix: drop spurious masa strptime in reminder_text

### DIFF
--- a/text.py
+++ b/text.py
@@ -7,38 +7,32 @@ async def reminder_text(chat_id, prayer, masa, next_prayer=None, next_prayer_tim
     
     prayer = prayer.capitalize()
 
-    try:
-        dt = datetime.strptime(masa, '%H:%M')
-        masa = dt.strftime('%I:%M %p')
-    except ValueError as e:
-        logger.error(f"ValueError converting masa to 12H, send_reminder: {e}")
-    finally:
-        header_art = '\U0001F54B'
+    header_art = '\U0001F54B'
 
-        if prayer == "Subuh":
-            header_art = '\U0001F30C'
-        if prayer == "Syuruk":
-            header_art = '\U0001F305'
-        if prayer == "Zohor":
-            header_art = '\U0001F3D9'
-        if prayer == "Asar":
-            header_art = '\U0001F307'
-        if prayer == "Maghrib":
-            header_art = '\U0001F304'
-        if prayer == "Isyak":
-            header_art = '\U0001F303'
+    if prayer == "Subuh":
+        header_art = '\U0001F30C'
+    if prayer == "Syuruk":
+        header_art = '\U0001F305'
+    if prayer == "Zohor":
+        header_art = '\U0001F3D9'
+    if prayer == "Asar":
+        header_art = '\U0001F307'
+    if prayer == "Maghrib":
+        header_art = '\U0001F304'
+    if prayer == "Isyak":
+        header_art = '\U0001F303'
 
-        reminder_message = f"{header_art} It is now *{prayer} ({masa})* {header_art}\n\n"
+    reminder_message = f"{header_art} It is now *{prayer} ({masa})* {header_art}\n\n"
 
-        if next_prayer and next_prayer_time:
-            reminder_message += f"*Next prayer:* {next_prayer.capitalize()} at *{next_prayer_time}*\n"
+    if next_prayer and next_prayer_time:
+        reminder_message += f"*Next prayer:* {next_prayer.capitalize()} at *{next_prayer_time}*\n"
 
-        if prayer == "Syuruk":
-            reminder_message += "\u2600\uFE0F The sun is up! \u2600\uFE0F"
-        else:
-            reminder_message += "May your fardh prayer be blessed! \U0001F932"
+    if prayer == "Syuruk":
+        reminder_message += "\u2600\uFE0F The sun is up! \u2600\uFE0F"
+    else:
+        reminder_message += "May your fardh prayer be blessed! \U0001F932"
 
-        return reminder_message
+    return reminder_message
 
 async def current_prayertimes(prayer_date=None, hijri_date=None, subuh_time=None, syuruk_time=None, zohor_time=None, asar_time=None, maghrib_time=None, isyak_time=None):
     message = ""


### PR DESCRIPTION
masa arrives at reminder_text already formatted as "HH:MM AM/PM" by formatData() upstream. The try/except block tries to parse it as "%H:%M" (24-hour), which silently fails on every reminder, gets caught by the except clause, and logs an error. The finally clause ran the rest of the function regardless, so output was correct by accident — but app.log got an error per reminder.

Removes the doomed conversion entirely; masa is already display-ready.