### PR TITLE
fix: /exit actually shuts down the bot

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from logs import logger
 import asyncio
+import os
 import telebot
 from telebot import apihelper
 from telebot.async_telebot import AsyncTeleBot
@@ -368,7 +369,11 @@ async def exitBot(message):
     if message.chat.id == 51719761:
         print("Admin has initiated bot shutdown.")
         logger.info("Admin has initiated bot shutdown.")
+        await sbot.send_message(message.chat.id, "Bot shutting down.")
         await shutdown()
+        # shutdown() only persists state; force-exit the process so the
+        # asyncio loop and Telegram polling actually stop.
+        os._exit(0)
     else:
         return
 


### PR DESCRIPTION
The /exit admin command called shutdown() which only persisted state and logged — the asyncio event loop and Telegram polling task kept running, so the process never actually stopped.

Now we send a confirmation message, persist state via shutdown(), then os._exit(0) to terminate the process. This skips the regular asyncio teardown but is fine on intentional shutdown.